### PR TITLE
Add comments + use rules_haskell 0.12 + update to ghc 8.6.5 + adapt to renaming in servant

### DIFF
--- a/haskell/src/BUILD.bazel
+++ b/haskell/src/BUILD.bazel
@@ -14,5 +14,5 @@ haskell_library(
         "@stackage//:wai",
         "@stackage//:warp",
     ],
-    visibility = ["//haskell:__subpackages__"],
+    visibility = ["//haskell/exe:__pkg__", "//haskell/test:__pkg__"],
 )

--- a/haskell/test/AppSpec.hs
+++ b/haskell/test/AppSpec.hs
@@ -29,9 +29,9 @@ spec = do
       it "throws a 404 for missing items" $ \ env -> do
         try env (getItem 42) `shouldThrow` errorsWithStatus notFound404
 
-errorsWithStatus :: Status -> ServantError -> Bool
+errorsWithStatus :: Status -> ClientError -> Bool
 errorsWithStatus status servantError = case servantError of
-  FailureResponse response -> responseStatusCode response == status
+  FailureResponse _ response -> responseStatusCode response == status
   _ -> False
 
 withClient :: IO Application -> SpecWith ClientEnv -> SpecWith ()


### PR DESCRIPTION
The point of these changes is to show something more up-to-date in the corresponding tweag blog post.